### PR TITLE
Add tests for age restricted search script

### DIFF
--- a/age_restricted_search.py
+++ b/age_restricted_search.py
@@ -1,0 +1,107 @@
+"""Utility for finding age-restricted YouTube videos for a query.
+
+This script mirrors the minimal example from the user request: it performs a
+search using the YouTube Data API, then filters the resulting videos so only
+those with ``contentDetails.contentRating.ytRating == "ytAgeRestricted"`` are
+returned.  The API key defaults to the value supplied in the prompt but can be
+overridden via the ``YOUTUBE_API_KEY`` environment variable or the
+``--api-key`` command line flag.  The query is provided via ``--query`` and
+defaults to ``"KHITANAN "`` (note the trailing space, as in the prompt).
+
+Usage::
+
+    python age_restricted_search.py --query "some search" [--api-key KEY]
+
+The script prints matching video titles and URLs to stdout, one per line.
+"""
+
+from __future__ import annotations
+
+import argparse
+import os
+from typing import List, Sequence, Tuple
+
+import requests
+
+
+DEFAULT_API_KEY = "AIzaSyDVvPQ7c830nznOc2U6BoaJETlzCoWP88o"
+DEFAULT_QUERY = "KHITANAN "
+
+
+def search_videos(api_key: str, query: str, *, max_results: int = 50) -> List[str]:
+    """Return a list of video IDs resulting from a YouTube search."""
+
+    params = {
+        "key": api_key,
+        "q": query,
+        "type": "video",
+        "maxResults": max_results,
+    }
+    response = requests.get("https://www.googleapis.com/youtube/v3/search", params=params)
+    response.raise_for_status()
+    payload = response.json()
+    items = payload.get("items", [])
+    return [item["id"]["videoId"] for item in items if "id" in item and "videoId" in item["id"]]
+
+
+def filter_age_restricted(api_key: str, video_ids: Sequence[str]) -> List[Tuple[str, str]]:
+    """Filter *video_ids* to those that are age restricted."""
+
+    if not video_ids:
+        return []
+
+    params = {
+        "key": api_key,
+        "id": ",".join(video_ids),
+        "part": "contentDetails,snippet",
+    }
+    response = requests.get("https://www.googleapis.com/youtube/v3/videos", params=params)
+    response.raise_for_status()
+    payload = response.json()
+
+    matches = []
+    for item in payload.get("items", []):
+        content_details = item.get("contentDetails", {})
+        rating = content_details.get("contentRating", {}).get("ytRating")
+        if rating == "ytAgeRestricted":
+            title = item.get("snippet", {}).get("title", "(untitled)")
+            video_id = item.get("id")
+            if video_id:
+                matches.append((title, f"https://www.youtube.com/watch?v={video_id}"))
+    return matches
+
+
+def parse_args(argv: Sequence[str] | None = None) -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument(
+        "--api-key",
+        default=os.getenv("YOUTUBE_API_KEY", DEFAULT_API_KEY),
+        help="YouTube Data API key (default: value from YOUTUBE_API_KEY env var or provided key)",
+    )
+    parser.add_argument(
+        "--query",
+        default=DEFAULT_QUERY,
+        help="Query string to search for (default: %(default)r)",
+    )
+    parser.add_argument(
+        "--max-results",
+        type=int,
+        default=50,
+        help="Maximum number of search results to retrieve (default: %(default)d)",
+    )
+    return parser.parse_args(argv)
+
+
+def main(argv: Sequence[str] | None = None) -> int:
+    args = parse_args(argv)
+    video_ids = search_videos(args.api_key, args.query, max_results=args.max_results)
+    matches = filter_age_restricted(args.api_key, video_ids)
+
+    for title, url in matches:
+        print(f"{title} {url}")
+
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/test_age_restricted_search.py
+++ b/tests/test_age_restricted_search.py
@@ -1,0 +1,116 @@
+import io
+import sys
+import types
+from pathlib import Path
+from unittest import mock
+
+ROOT = Path(__file__).resolve().parents[1]
+if str(ROOT) not in sys.path:
+    sys.path.insert(0, str(ROOT))
+
+if "requests" not in sys.modules:
+    requests_stub = types.ModuleType("requests")
+    requests_stub.get = None
+    sys.modules["requests"] = requests_stub
+
+import age_restricted_search as ars
+
+
+def _mock_response(json_data):
+    response = mock.Mock()
+    response.raise_for_status.return_value = None
+    response.json.return_value = json_data
+    return response
+
+
+def test_search_videos_returns_only_items_with_video_ids():
+    json_payload = {
+        "items": [
+            {"id": {"videoId": "abc"}},
+            {"id": {"kind": "youtube#video"}},
+            {"not_id": {}},
+            {"id": {"videoId": "def"}},
+        ]
+    }
+    mock_resp = _mock_response(json_payload)
+    with mock.patch.object(ars.requests, "get", return_value=mock_resp) as mock_get:
+        video_ids = ars.search_videos("api-key", "query", max_results=25)
+
+    assert video_ids == ["abc", "def"]
+    mock_get.assert_called_once_with(
+        "https://www.googleapis.com/youtube/v3/search",
+        params={
+            "key": "api-key",
+            "q": "query",
+            "type": "video",
+            "maxResults": 25,
+        },
+    )
+
+
+def test_filter_age_restricted_returns_titles_and_urls():
+    json_payload = {
+        "items": [
+            {
+                "id": "vid1",
+                "contentDetails": {"contentRating": {"ytRating": "ytAgeRestricted"}},
+                "snippet": {"title": "First"},
+            },
+            {
+                "id": "vid2",
+                "contentDetails": {"contentRating": {"ytRating": "ytSomethingElse"}},
+                "snippet": {"title": "Second"},
+            },
+            {
+                "id": "vid3",
+                "contentDetails": {},
+                "snippet": {"title": "Third"},
+            },
+            {
+                "id": "vid4",
+                "contentDetails": {"contentRating": {"ytRating": "ytAgeRestricted"}},
+                "snippet": {},
+            },
+        ]
+    }
+    mock_resp = _mock_response(json_payload)
+    with mock.patch.object(ars.requests, "get", return_value=mock_resp) as mock_get:
+        matches = ars.filter_age_restricted("api-key", ["vid1", "vid2", "vid3", "vid4"])
+
+    assert matches == [
+        ("First", "https://www.youtube.com/watch?v=vid1"),
+        ("(untitled)", "https://www.youtube.com/watch?v=vid4"),
+    ]
+    mock_get.assert_called_once_with(
+        "https://www.googleapis.com/youtube/v3/videos",
+        params={
+            "key": "api-key",
+            "id": "vid1,vid2,vid3,vid4",
+            "part": "contentDetails,snippet",
+        },
+    )
+
+
+def test_filter_age_restricted_skips_network_call_when_no_ids():
+    with mock.patch.object(ars.requests, "get") as mock_get:
+        matches = ars.filter_age_restricted("api-key", [])
+
+    assert matches == []
+    mock_get.assert_not_called()
+
+
+def test_main_prints_each_match_on_its_own_line():
+    with mock.patch.object(ars, "search_videos", return_value=["one", "two"]) as mock_search, \
+        mock.patch.object(
+            ars,
+            "filter_age_restricted",
+            return_value=[("Title 1", "url1"), ("Title 2", "url2")],
+        ) as mock_filter:
+        buffer = io.StringIO()
+        with mock.patch("sys.stdout", buffer):
+            exit_code = ars.main(["--api-key", "token", "--query", "term", "--max-results", "10"])
+
+    assert exit_code == 0
+    assert buffer.getvalue() == "Title 1 url1\nTitle 2 url2\n"
+    mock_search.assert_called_once_with("token", "term", max_results=10)
+    mock_filter.assert_called_once_with("token", ["one", "two"])


### PR DESCRIPTION
## Summary
- add unit tests for the YouTube age-restricted search script covering search, filtering, and CLI output behavior

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68cd3f5703c8832abc12b2155a6cf19d